### PR TITLE
Kfb/ranking ties

### DIFF
--- a/java/src/mloss/roc/Curve.java
+++ b/java/src/mloss/roc/Curve.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import java.util.Arrays;
 
 // TODO: handle case where classifier output is a weak ranking, e.g. class labels
 
@@ -203,6 +204,65 @@ public class Curve {
     }
 
     /**
+     * Creates a classification result analysis suitable for producing
+     * ROC and PR curves when there instances in the ranking that are
+     * indistinguishable, i.e. ties in the ranking.
+     *
+     * @param rankedLabels A list containing the true label for each
+     * example in the order of classified most likely positive to
+     * classified most likely negative. (The numbers used to rank the
+     * labels are not part of the ranked labels.)
+     * @param runLengths A list containing runs of indistinguishable
+     * labels in the rankedLabels list. Classification thresholds are
+     * only possible between runs, not within a run (when
+     * runLengths[i] is greater than 1, indicating ties in the
+     * ranking).
+     * @param positiveLabel The label that will be considered
+     * positive. All other labels are considere negative. This allows
+     * for handling multiple classes without having to rewrite all the
+     * labels into some prespecified positive and negative signifiers.
+     */
+    public Curve(int[] rankedLabels, int[] runLengths, int positiveLabel) {
+        initFields(runLengths.length);
+        buildCounts(rankedLabels, runLengths, positiveLabel);
+    }
+
+    /**
+     * Calls {@link #Curve(int[], int[], int)} with positiveLabel=1
+     * (the default positive label for integers).
+     */
+    /* Already have constructor with 2 int arrays.
+      public Curve(int[] rankedLabels, int[] runLengths) {
+        this(rankedLabels, runLengths, 1);
+      }
+    */
+
+    /**
+     * Creates a classification result analysis suitable for producing
+     * ROC and PR curves when there instances in the ranking that are
+     * indistinguishable, i.e. ties in the ranking. This is the
+     * version to use for collections of number objects.
+     *
+     * @param rankedLabels A list containing the true label for each
+     * example in the order of classified most likely positive to
+     * classified most likely negative. (The numbers used to rank the
+     * labels are not part of the ranked labels.)
+     * @param runLengths A list containing runs of indistinguishable
+     * labels in the rankedLabels list. Classification thresholds are
+     * only possible between runs, not within a run (when
+     * runLengths[i] is greater than 1, indicating ties in the
+     * ranking).
+     * @param positiveLabel The label that will be considered
+     * positive. All other labels are considere negative. This allows
+     * for handling multiple classes without having to rewrite all the
+     * labels into some prespecified positive and negative signifiers.
+     */
+    public <T> Curve(List<T> rankedLabels, int[] runLengths, T positiveLabel) {
+        initFields(runLengths.length);
+        buildCounts(rankedLabels, runLengths, positiveLabel);
+    }
+
+    /**
      * Counts and stores the numbers of correctly-classified positives
      * and negatives at each threshold level.
      *
@@ -239,6 +299,81 @@ public class Curve {
             truePositiveCounts[labelIndex + 1] = totalPositives;
             falsePositiveCounts[labelIndex + 1] = totalNegatives;
             labelIndex++;
+        }
+    }
+
+    /**
+     * Counts and stores the numbers of correctly-classified positives
+     * and incorrectly classified negatives at each threshold between
+     * a run of ties.
+     *
+     * @param rankedLabels A list containing the true label for each
+     * example. The labels must already by ordered (ranked) from most
+     * likely positive to most likely negative.
+     * @param runLengths A list containing runs of tied examples in
+     * the ranking.
+     * @param positiveLabel The label that will be considered positive.
+     */
+    void buildCounts(int[] rankedLabels, int[] runLengths,
+                     int positiveLabel) {
+        // Calculate the individual confusion matrices
+        int runIndex = 0;
+        int nextThreshold = runLengths[runIndex];
+        for (int labelIndex = 0; labelIndex < rankedLabels.length;
+             labelIndex++) {
+            if (rankedLabels[labelIndex] == positiveLabel) {
+                totalPositives++;
+            } else {
+                totalNegatives++;
+            }
+            // check if between runs
+            if (labelIndex + 1 == nextThreshold) {
+                truePositiveCounts[runIndex + 1] = totalPositives;
+                falsePositiveCounts[runIndex + 1] = totalNegatives;
+                runIndex++;
+                if (runIndex < runLengths.length) {
+                    nextThreshold += runLengths[runIndex];
+                }
+            }
+        }
+
+        if (runIndex != runLengths.length ||
+            nextThreshold != rankedLabels.length) {
+            throw new IllegalArgumentException("Sum of run lengths must equal length of rankedLabels.");
+        }
+    }
+
+    /**
+     * Generic collections version of {@link #buildCounts(int[],
+     * int[], int)}.
+     */
+    <T> void buildCounts(Iterable<T> rankedLabels, int[] runLengths,
+                         T positiveLabel) {
+        // Calculate the individual confusion matrices
+        int labelIndex = 0;
+        int runIndex = 0;
+        int nextThreshold = runLengths[runIndex];
+        for (T label : rankedLabels) {
+            if (label.equals(positiveLabel)) {
+                totalPositives++;
+            } else {
+                totalNegatives++;
+            }
+            // check if between runs
+            if (labelIndex + 1 == nextThreshold) {
+                truePositiveCounts[runIndex + 1] = totalPositives;
+                falsePositiveCounts[runIndex + 1] = totalNegatives;
+                runIndex++;
+                if (runIndex < runLengths.length) {
+                    nextThreshold += runLengths[runIndex];
+                }
+            }
+            labelIndex++;
+        }
+
+        if (runIndex != runLengths.length ||
+            nextThreshold != labelIndex) {
+            throw new IllegalArgumentException("Sum of run lengths must equal length of rankedLabels.");
         }
     }
 
@@ -925,6 +1060,9 @@ public class Curve {
             // Check if it is OK to proceed (throws exception if not)
             checkValidBuilderState();
 
+            // Lengths of tied subsequences in the ranked labels list
+            int runLengths[];
+
             // Create a list of ranked labels if not already given
             if (rankedLabels == null) {
                 // Rank actuals by predicteds using a stable sort.
@@ -946,9 +1084,32 @@ public class Curve {
                 // Sort in reverse order to make a ranking
                 Collections.sort(sorted, new TupleScoreReverseComparator(comparator));
                 rankedLabels = new ArrayList<TLabel>(sorted.size());
+                ArrayList<Integer> dynamicRunLengths = new ArrayList<Integer>();
+                int currentRunLength = -1;
+                // Keep previous tuple to check for ties in predicteds
+                Tuple previous = null;
                 for (Tuple tuple : sorted) {
                     rankedLabels.add(tuple.label);
+
+                    if (previous != null && tuple.score.equals(previous.score)) {
+                        // tied
+                        currentRunLength++;
+                    }
+                    else {
+                        if (currentRunLength != -1) {
+                            dynamicRunLengths.add(currentRunLength);
+                        }
+                        currentRunLength = 1;
+                    }
+                    previous = tuple;
                 }
+                // Add the final set of scores
+                dynamicRunLengths.add(currentRunLength);
+
+                // Convert to primitive int[] array
+                runLengths = new int[dynamicRunLengths.size()];
+                for (int i = 0; i < dynamicRunLengths.size(); i++) runLengths[i] = dynamicRunLengths.get(i);
+
                 // Make sure the weights are in the ranked order too
                 if (weights != null) {
                     // Create a new list so that the original one is left unmodified
@@ -958,9 +1119,14 @@ public class Curve {
                     }
                 }
             }
+            else {
+                // runLengths are all 1
+                runLengths = new int[rankedLabels.size()];
+                Arrays.fill(runLengths, 1);
+            }
 
             // TODO pass weights if specified
-            return new Curve(rankedLabels, positiveLabel);
+            return new Curve(rankedLabels, runLengths, positiveLabel);
         }
 
         /**

--- a/java/src/mloss/roc/Curve.java
+++ b/java/src/mloss/roc/Curve.java
@@ -184,14 +184,6 @@ public class Curve {
     }
 
     /**
-     * Calls {@link #Curve(int[], int)} with positiveLabel=1 (the
-     * default positive label for integers).
-     */
-    public Curve(int[] rankedLabels) {
-        this(rankedLabels, 1);
-    }
-
-    /**
      * Creates a classification result analysis suitable for producing
      * ROC and PR curves.  This is the version to use for collections of
      * number objects.

--- a/java/test/mloss/roc/CurveBuilderRankingTiesTest.java
+++ b/java/test/mloss/roc/CurveBuilderRankingTiesTest.java
@@ -1,0 +1,93 @@
+package mloss.roc;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import mloss.roc.util.IterableArray;
+
+
+/** Tests {@link Curve.Builder}. */
+public class CurveBuilderRankingTiesTest {
+
+    /** Tests {@link Curve.Builder} when predicteds contains ties. */
+    @Test public void testRankingTiesCollection() {
+        /*
+          Predicted Actual
+          3         1
+          3         1
+          3         1
+          3         0
+          2         1
+          2         0
+          1         1
+          1         0
+        */
+        // Predicted and actuals with ties in predicteds
+        Integer[] predictedsArray = {
+            3, 1, 1, 2, 3, 3, 2, 3
+        };
+        Integer[] actualsArray = {
+            0, 1, 0, 1, 1, 1, 0, 1
+        };
+        Iterable<Integer> predictedsSequence =
+            new IterableArray<Integer>(predictedsArray);
+        Iterable<Integer> actualsSequence =
+            new IterableArray<Integer>(actualsArray);
+
+        // Positive label
+        Integer positiveLabel = new Integer(1);
+
+        // Correct counts based on above data
+        int[] posCounts = {0, 3, 4, 5 };
+        int[] negCounts = {0, 1, 2, 3 };
+
+        // Object under test
+        Curve.Builder<Integer, Integer> builder =
+            new Curve.Builder<Integer, Integer>();
+
+        // Construct curve
+        Curve curve = builder.predicteds(predictedsSequence).actuals(actualsSequence)
+            .positiveLabel(positiveLabel).build();
+
+        assertArrayEquals(posCounts, curve.truePositiveCounts);
+        assertArrayEquals(negCounts, curve.falsePositiveCounts);
+    }
+
+    /** Tests {@link Curve.PrimitiveBuilder} when predicteds contains
+     * ties.
+     */
+    @Test public void testRankingTiesPrimitive() {
+        // Use predicteds that are exactly representable in doubles to
+        // avoid floating point comparisons for this test.
+        /*
+          Predicted Actual
+          3.0       1
+          3.0       1
+          3.0       1
+          3.0       0
+          2.0       1
+          2.0       0
+          1.0       1
+          1.0       0
+        */
+
+        // Predicted and actuals with ties
+        double predicteds[] = { 3.0, 1.0, 1.0, 2.0, 3.0, 3.0, 2.0, 3.0 };
+        int actuals[] = { 0, 1, 0, 1, 1, 1, 0, 1 };
+
+        int positiveLabel = 1;
+
+        // Correct counts based on above data
+        int[] posCounts = {0, 3, 4, 5 };
+        int[] negCounts = {0, 1, 2, 3 };
+
+        Curve.PrimitivesBuilder builder = new Curve.PrimitivesBuilder();
+
+        // Construct curve
+        Curve curve = builder.predicteds(predicteds).actuals(actuals)
+            .positiveLabel(positiveLabel).build();
+
+        assertArrayEquals(posCounts, curve.truePositiveCounts);
+        assertArrayEquals(negCounts, curve.falsePositiveCounts);
+    }
+}

--- a/java/test/mloss/roc/CurveTest.java
+++ b/java/test/mloss/roc/CurveTest.java
@@ -57,9 +57,9 @@ public class CurveTest {
     Curve staircaseCurve;
 
     @Before public void setUp() {
-        curve = new Curve(labelsAverage);
+        curve = new Curve(labelsAverage, 1);
         randCurve = new Curve(random_posCounts, random_negCounts);
-        staircaseCurve = new Curve(staircaseLabels);
+        staircaseCurve = new Curve(staircaseLabels, 1);
     }
 
     /**
@@ -67,31 +67,31 @@ public class CurveTest {
      * Curve.buildCounts(int[], int)}.
      */
     @Test public void testBuildCountsFromHardLabels() {
-        Curve curve = new Curve(labelsWorst);
+        Curve curve = new Curve(labelsWorst, 1);
         assertArrayEquals(labelsWorst_posCounts, curve.truePositiveCounts);
         assertArrayEquals(labelsWorst_negCounts, curve.falsePositiveCounts);
         assertEquals(5, curve.totalPositives);
         assertEquals(2, curve.totalNegatives);
 
-        curve = new Curve(labelsWorst, 0);  // Non-default positive label
+        curve = new Curve(labelsWorst, 0); // Change positive label
         assertArrayEquals(labelsWorst_negCounts, curve.truePositiveCounts);
         assertArrayEquals(labelsWorst_posCounts, curve.falsePositiveCounts);
         assertEquals(2, curve.totalPositives);
         assertEquals(5, curve.totalNegatives);
 
-        curve = new Curve(labelsAverage);
+        curve = new Curve(labelsAverage, 1);
         assertArrayEquals(labelsAverage_posCounts, curve.truePositiveCounts);
         assertArrayEquals(labelsAverage_negCounts, curve.falsePositiveCounts);
         assertEquals(5, curve.totalPositives);
         assertEquals(5, curve.totalNegatives);
 
-        curve = new Curve(labelsAverage, 0);  // Non-default positive label
+        curve = new Curve(labelsAverage, 0);  // Change positive label
         assertArrayEquals(labelsAverage_negCounts, curve.truePositiveCounts);
         assertArrayEquals(labelsAverage_posCounts, curve.falsePositiveCounts);
         assertEquals(5, curve.totalPositives);
         assertEquals(5, curve.totalNegatives);
 
-        curve = new Curve(labelsBest);
+        curve = new Curve(labelsBest, 1);
         assertArrayEquals(labelsBest_posCounts, curve.truePositiveCounts);
         assertArrayEquals(labelsBest_negCounts, curve.falsePositiveCounts);
         assertEquals(2, curve.totalPositives);
@@ -528,7 +528,7 @@ public class CurveTest {
         Arrays.fill(labels, 0, n, 1);
         // Negatives (0) come after.
         Arrays.fill(labels, n, n+n, 0);
-        Curve hugeCurve = new Curve(labels);
+        Curve hugeCurve = new Curve(labels, 1);
         double expectedRocArea = 1.0;
         assertEquals(expectedRocArea, hugeCurve.rocArea(), TOLERANCE);
         double[] expectedMannWhitneyU = {0.0, (double) n * (double) n};
@@ -540,7 +540,7 @@ public class CurveTest {
         Arrays.fill(labels, 0, n, 0);
         // Positives (1) come after.
         Arrays.fill(labels, n, n+n, 1);
-        hugeCurve = new Curve(labels);
+        hugeCurve = new Curve(labels, 1);
         expectedRocArea = 0.0;
         assertEquals(expectedRocArea, hugeCurve.rocArea(), TOLERANCE);
         expectedMannWhitneyU = new double[]{(double) n * (double) n, 0.0};

--- a/java/test/mloss/roc/CurveTest.java
+++ b/java/test/mloss/roc/CurveTest.java
@@ -6,6 +6,7 @@
 package mloss.roc;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import org.junit.Before;
@@ -546,5 +547,70 @@ public class CurveTest {
         expectedMannWhitneyU = new double[]{(double) n * (double) n, 0.0};
         assertArrayEquals(expectedMannWhitneyU, hugeCurve.mannWhitneyU(),
                           TOLERANCE);
+    }
+
+    @Test public void testRunLengthsPrimitiveConstructor() {
+        int[] rankedLabels = {1, 0, 1, 1, 0, 0};
+
+        // everything is tied
+        Curve curve = new Curve(rankedLabels, new int[]{6}, 1);
+        int[] expectedPosCounts = {0, 3};
+        int[] expectedNegCounts = {0, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+
+        // run of length 3
+        curve = new Curve(rankedLabels, new int[]{1, 1, 3, 1}, 1);
+        expectedPosCounts = new int[]{0, 1, 1, 3, 3};
+        expectedNegCounts = new int[]{0, 0, 1, 2, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+
+        // 2 separate runs
+        curve = new Curve(rankedLabels, new int[]{2, 1, 1, 2}, 1);
+        expectedPosCounts = new int[]{0, 1, 2, 3, 3};
+        expectedNegCounts = new int[]{0, 1, 1, 1, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+
+        // no ties
+        curve = new Curve(rankedLabels, new int[]{1, 1, 1, 1, 1, 1}, 1);
+        expectedPosCounts = new int[]{0, 1, 1, 2, 3, 3, 3};
+        expectedNegCounts = new int[]{0, 0, 1, 1, 1, 2, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+    }
+
+    @Test public void testRunLengthGenericConstructor() {
+        String[] rankedLabelsArray = {"true", "false", "true", "true", "false", "false"};
+        List<String> rankedLabels = Arrays.asList(rankedLabelsArray);
+
+        // everything is tied
+        Curve curve = new Curve(rankedLabels, new int[]{6}, "true");
+        int[] expectedPosCounts = {0, 3};
+        int[] expectedNegCounts = {0, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+
+        // run of length 3
+        curve = new Curve(rankedLabels, new int[]{1, 1, 3, 1}, "true");
+        expectedPosCounts = new int[]{0, 1, 1, 3, 3};
+        expectedNegCounts = new int[]{0, 0, 1, 2, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+
+        // 2 separate runs
+        curve = new Curve(rankedLabels, new int[]{2, 1, 1, 2}, "true");
+        expectedPosCounts = new int[]{0, 1, 2, 3, 3};
+        expectedNegCounts = new int[]{0, 1, 1, 1, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
+
+        // no ties
+        curve = new Curve(rankedLabels, new int[]{1, 1, 1, 1, 1, 1}, "true");
+        expectedPosCounts = new int[]{0, 1, 1, 2, 3, 3, 3};
+        expectedNegCounts = new int[]{0, 0, 1, 1, 1, 2, 3};
+        assertArrayEquals(expectedPosCounts, curve.truePositiveCounts);
+        assertArrayEquals(expectedNegCounts, curve.falsePositiveCounts);
     }
 }


### PR DESCRIPTION
First pass at properly handling ties in the ranking. I don't think this is really ready to be merged just yet, but wanted to make it visible and get some feedback to keep moving forward on issue #16.

Some questions and thoughts.
1. I agree that consolidating the Curve constructors and build method would be helpful, though for now there are both primitive array and collection versions. Should we just take the plunge and have only primitive arrays for the Curve constructors and allow the Builder to convert from collections as necessary?
2. I'm currently ignoring any floating point comparison subtleties when detecting ties. Do we want to support an absolute or relative epsilon to detect effective ties even if the double representation is slightly different? My thought is no, and if ties are important, then double should not be the predicteds type and int or some other discrete type should be used.
3. The code to create the runLenghts array in Curve.Builder.build seems clunky right now. Maybe it is cleaner to not use the for each iterator and have a for loop over indices so the next tuple can be easily checked.
4. We should probably add some more tests. I have super simple tests of the basic functionality right now and am not sure what corner cases we need to consider.

Thoughts on all of this, @afbarnard?
